### PR TITLE
Pre-allocate capacity for definition & repetition levels

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
@@ -212,8 +212,10 @@ public abstract class PrimitiveColumnReader
 
     public ColumnChunk readPrimitive(Field field)
     {
-        IntList definitionLevels = new IntArrayList();
-        IntList repetitionLevels = new IntArrayList();
+        // Pre-allocate these arrays to the necessary size. This saves a substantial amount of
+        // CPU time by avoiding container resizing.
+        IntList definitionLevels = new IntArrayList(nextBatchSize);
+        IntList repetitionLevels = new IntArrayList(nextBatchSize);
         seek();
         BlockBuilder blockBuilder = field.getType().createBlockBuilder(null, nextBatchSize);
         int valueCount = 0;


### PR DESCRIPTION
Testing shows 5% to 15% performance improvement on a lot of queries by pre-reserving capacity for definitionLevels and repetitionLevels.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description

I did profiling on Trino while doing TPCDS queries from a Parquet source and noticed that a lot of them were wasting time on array copy while growing capacity of the definitionLevels and definitionLevels integer array lists. Pre-reserving capacity sped up a lot of queries, some as much as 15%.

<!-- Answer the following questions to help reviewers and maintainers
understand this PR's scope at a glance:
-->

> Is this change a fix, improvement, new feature, refactoring, or other?
Improvement

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)
Change to the parquet reader component

> How would you describe this change to a non-technical end user or system administrator?
Speed up parquet column reading a bit by pre-reserving capacity in some of the containers.

## Related issues, pull requests, and links

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->
Performance optimization

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
